### PR TITLE
Pea/plugins updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,19 @@
                     "reference": "main"
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "chatwoot/wp-plugin",
+                "version": "dev-main",
+                "type": "wordpress-plugin",
+                "source": {
+                    "type": "git",
+                    "url": "git@github.com:chatwoot/wp-plugin.git",
+                    "reference": "main"
+                }
+            }
         }
     ],
     "require": {
@@ -123,6 +136,7 @@
         "wpackagist-plugin/block-manager": "^1.2.2",
         "debtcollective/block-visibility-pro": "dev-main",
         "wpackagist-plugin/block-visibility": "^2.3.0",
+        "chatwoot/wp-plugin": "dev-main",
         "wpackagist-plugin/contact-form-7": "^5.5.2",
         "wpackagist-plugin/contact-form-entries": "^1.2.7",
         "wpackagist-plugin/members": "^3.1.5",
@@ -151,6 +165,7 @@
         "installer-paths": {
             "wp-content/plugins/site-functionality/": ["debtcollective/dotorg-site-functionality"],
             "wp-content/themes/debtcollective/": ["debtcollective/dotorg-theme"],
+            "wp-content/themes/chatwoot/": ["chatwoot/wp-plugin"],
             "wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
             "wp-content/themes/{$name}/": ["type:wordpress-theme"]
         },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "type": "package",
             "package": {
               "name": "advanced-custom-fields/advanced-custom-fields-pro",
-              "version": "5.10.2",
+              "version": "5.12",
               "type": "wordpress-plugin",
               "dist": {
                 "type": "zip",
@@ -130,9 +130,9 @@
         }
     ],
     "require": {
-        "advanced-custom-fields/advanced-custom-fields-pro": "^5.10.2",
         "wpackagist-plugin/codepress-admin-columns": "^4.3.2",
         "wpackagist-plugin/flexy-breadcrumb": "^1.1.4",
+        "advanced-custom-fields/advanced-custom-fields-pro": "^5.12",
         "wpackagist-plugin/block-manager": "^1.2.2",
         "debtcollective/block-visibility-pro": "dev-main",
         "wpackagist-plugin/block-visibility": "^2.3.0",

--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
         "wpackagist-plugin/contact-form-7": "^5.5.2",
         "wpackagist-plugin/contact-form-entries": "^1.2.7",
         "wpackagist-plugin/flexy-breadcrumb": "^1.1.4",
+        "wpackagist-plugin/cookie-law-info": "^2.1.1",
         "wpackagist-plugin/members": "^3.1.5",
         "wpackagist-plugin/page-links-to": "^3.3.5",
         "wpackagist-plugin/redirection": "^5.1.3",

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,8 @@
     "require-dev": {
         "wpackagist-plugin/broken-link-checker": "^1.11.16",
         "wpackagist-plugin/user-switching": "^1.5.8",
-        "wpackagist-plugin/wp-log-viewer": "^1.2.1"
+        "wpackagist-plugin/wp-log-viewer": "^1.2.1",
+        "wpackagist-plugin/wp-crontrol": "^1.12.0"
     },
     "extra": {
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -147,8 +147,6 @@
         "wpackagist-plugin/autodescription": "^4.2.2",
         "wpackagist-plugin/social-sharing-block": "^0.3.0",
         "wpackagist-plugin/svg-support": "^2.4",
-        "wpackagist-plugin/wp-discourse": "^2.3.0",
-        "scossar/wp-discourse-shortcodes": "dev-master",
         "wpackagist-plugin/wp-rest-api-v2-menus": "^0.10",
         "wpackagist-plugin/amazon-s3-and-cloudfront": "^2.5.5",
         "wpackagist-plugin/wp-mail-smtp": "^3.2.1",

--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,7 @@
         "wpackagist-plugin/page-links-to": "^3.3.5",
         "wpackagist-plugin/reusable-blocks-extended": "^0.8",
         "wpackagist-plugin/redirection": "^5.1.3",
+        "wpackagist-plugin/google-site-kit": "^1.68.0",
         "wpackagist-plugin/autodescription": "^4.2.2",
         "wpackagist-plugin/social-sharing-block": "^0.3.0",
         "wpackagist-plugin/svg-support": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -131,34 +131,34 @@
     ],
     "require": {
         "wpackagist-plugin/codepress-admin-columns": "^4.3.2",
-        "wpackagist-plugin/flexy-breadcrumb": "^1.1.4",
         "advanced-custom-fields/advanced-custom-fields-pro": "^5.12",
         "wpackagist-plugin/block-manager": "^1.2.2",
-        "debtcollective/block-visibility-pro": "dev-main",
         "wpackagist-plugin/block-visibility": "^2.3.0",
+        "debtcollective/block-visibility-pro": "dev-main",
         "chatwoot/wp-plugin": "dev-main",
         "wpackagist-plugin/contact-form-7": "^5.5.2",
         "wpackagist-plugin/contact-form-entries": "^1.2.7",
+        "wpackagist-plugin/flexy-breadcrumb": "^1.1.4",
         "wpackagist-plugin/members": "^3.1.5",
         "wpackagist-plugin/page-links-to": "^3.3.5",
-        "wpackagist-plugin/reusable-blocks-extended": "^0.8",
         "wpackagist-plugin/redirection": "^5.1.3",
+        "wpackagist-plugin/reusable-blocks-extended": "^0.8",
         "wpackagist-plugin/google-site-kit": "^1.68.0",
-        "wpackagist-plugin/autodescription": "^4.2.2",
         "wpackagist-plugin/social-sharing-block": "^0.3.0",
         "wpackagist-plugin/svg-support": "^2.4",
-        "wpackagist-plugin/wp-rest-api-v2-menus": "^0.10",
-        "wpackagist-plugin/amazon-s3-and-cloudfront": "^2.5.5",
+        "wpackagist-plugin/autodescription": "^4.2.2",
         "wpackagist-plugin/wp-mail-smtp": "^3.2.1",
+        "wpackagist-plugin/amazon-s3-and-cloudfront": "^2.5.5",
+        "wpackagist-plugin/wp-user-avatars": "^1.4.1",
+        "wpackagist-plugin/wp-rest-api-v2-menus": "^0.10",
         "debtcollective/wp-action-network-events": "dev-main",
         "debtcollective/dotorg-site-functionality": "dev-main",
         "debtcollective/dotorg-theme": "dev-main",
-        "wpackagist-plugin/wp-user-avatars": "^1.4.1",
         "vlucas/phpdotenv": "^5.4.0"
     },
     "require-dev": {
         "wpackagist-plugin/broken-link-checker": "^1.11.16",
-        "wpackagist-plugin/user-switching": "^1.5.8"
+        "wpackagist-plugin/user-switching": "^1.5.8",
         "wpackagist-plugin/wp-log-viewer": "^1.2.1"
     },
     "extra": {
@@ -173,5 +173,11 @@
             "dotenv-path": ".",
             "dotenv-name": ".env"
           }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "ffraenz/private-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -144,6 +144,7 @@
         "vlucas/phpdotenv": "^5.4.0"
     },
     "require-dev": {
+        "wpackagist-plugin/broken-link-checker": "^1.11.16",
         "wpackagist-plugin/user-switching": "^1.5.8"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
     "require-dev": {
         "wpackagist-plugin/broken-link-checker": "^1.11.16",
         "wpackagist-plugin/user-switching": "^1.5.8"
+        "wpackagist-plugin/wp-log-viewer": "^1.2.1"
     },
     "extra": {
         "installer-paths": {


### PR DESCRIPTION
Update composer.json to match current plugin set.

Note: `require-dev` should only be installed on staging. The production site should use `--no-dev` flag when running composer commands on prod.

See https://getcomposer.org/doc/03-cli.md#composer-no-dev for details